### PR TITLE
Fix `this.emit is not a function` error

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,14 +342,6 @@ class TelnetServer
       socket.fresh = true;
       listener(socket);
     });
-
-    this.netServer.on('error', error => {
-      this.emit('error', error);
-    });
-
-    this.netServer.on('uncaughtException', error => {
-      this.emit('uncaughtException', error);
-    });
   }
 }
 


### PR DESCRIPTION
Addresses the error described in #1 favoring the removal of the listeners. As it stands, referencing `TelnetServer.netServer` is the norm. If this changes, it would be worth having `TelnetServer` extend `EventEmitter` and reverting these changes.