### PR TITLE
Strip the last byte if it's a carriage return only

### DIFF
--- a/index.js
+++ b/index.js
@@ -321,11 +321,16 @@ class TelnetSocket extends EventEmitter
       return;
     }
 
+    // strip '\r' if the last byte
+    if (cleanbuf[cleanlen - 1] == 13) {
+      cleanbuf = cleanbuf.slice(0, cleanlen - 1);
+    }
+
     /**
      * @event TelnetSocket#data
      * @param {Buffer} data
      */
-    this.emit('data', cleanbuf.slice(0, cleanlen - 1));
+    this.emit('data', cleanbuf);
   }
 }
 


### PR DESCRIPTION
Otherwise it seems to be stripping the last byte always, which may be a
character that matters.

I have a client that sends `command\n` and ranvier internals is only receiving `comman`. Switching to this, the internals receives `command` and also still strips `\r` if present.