### PR TITLE
Fix:  Handle any combination or order of CR and LF as command delimiters.

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,10 +131,10 @@ class TelnetSocket extends EventEmitter
   sendGMCP(gmcpPackage, data) {
     const gmcpData = gmcpPackage + ' ' + JSON.stringify(data);
     const dataBuffer = Buffer.from(gmcpData);
-    const seqStartBuffer = new Buffer([Seq.IAC, Seq.SB]);
+    const seqStartBuffer = new Buffer([Seq.IAC, Seq.SB, Opts.OPT_GMCP]);
     const seqEndBuffer = new Buffer([Seq.IAC, Seq.SE]);
 
-    this.socket.write(Buffer.concat([seqStartBuffer, dataBuffer, seqEndBuffer], gmcpData.length + 4));
+    this.socket.write(Buffer.concat([seqStartBuffer, dataBuffer, seqEndBuffer], gmcpData.length + 5));
   }
 
   attach(connection) {

--- a/index.js
+++ b/index.js
@@ -224,7 +224,11 @@ class TelnetSocket extends EventEmitter
 
     while (i < inputbuf.length) {
       if (inputbuf[i] !== Seq.IAC) {
-        cleanbuf[cleanlen++] = inputbuf[i++];
+        if (inputbuf[i] < 32) { // Skip any freaky control codes.
+          i++;
+        } else {
+          cleanbuf[cleanlen++] = inputbuf[i++];
+        }
         continue;
       }
 

--- a/index.js
+++ b/index.js
@@ -170,11 +170,13 @@ class TelnetSocket extends EventEmitter
       // them separately. Some client auto-connect features do this
       let bucket = [];
       for (let i = 0; i < inputlen; i++) {
-        if (databuf[i] !== 10) { // \n
+        if (databuf[i] !== 10 && databuf[i] !== 13) { // neither LF nor CR
           bucket.push(databuf[i]);
         } else {
-          this.input(Buffer.from(bucket));
-          bucket = [];
+          if (bucket.length) {
+            this.input(Buffer.from(bucket));
+            bucket = [];
+          }
         }
       }
 
@@ -325,7 +327,7 @@ class TelnetSocket extends EventEmitter
      * @event TelnetSocket#data
      * @param {Buffer} data
      */
-    this.emit('data', cleanbuf.slice(0, cleanlen - 1));
+    this.emit('data', cleanbuf.slice(0, cleanlen >= cleanbuf.length ? undefined : cleanlen));  // special processing required for slice() to work.
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -173,10 +173,13 @@ class TelnetSocket extends EventEmitter
         if (databuf[i] !== 10 && databuf[i] !== 13) { // neither LF nor CR
           bucket.push(databuf[i]);
         } else {
-          if (bucket.length) {
-            this.input(Buffer.from(bucket));
-            bucket = [];
+          // look ahead to see if our newline delimiter is part of a combo.
+          if (i+1 < inputlen && (databuf[i+1] === 10 || databuf[i+1 === 13])
+            && databuf[i] !== databuf[i+1]) {
+            i++;
           }
+          this.input(Buffer.from(bucket));
+          bucket = [];
         }
       }
 


### PR DESCRIPTION
Currently, the game assumes that your commands always end with CRLF.  However, some terminals commonly send just LF.  The game does not handle this appropriately, chopping off the last byte, assuming it was a CR.

Solution: attach() avoids adding either CR or LF.  If it comes across one of them, process the data up to that point with a call to input().  input() then no longer unconditionally removes the last character, assuming it's a CR.  However, we still need specialized logic in our call to slice() because of the way it works.  This is because input() may either have been given clean data from the start, or it may have had to remove negotiation characters.