### PR TITLE
Fix: sendGMCP() now actually sends GMCP data.

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,10 +131,10 @@ class TelnetSocket extends EventEmitter
   sendGMCP(gmcpPackage, data) {
     const gmcpData = gmcpPackage + ' ' + JSON.stringify(data);
     const dataBuffer = Buffer.from(gmcpData);
-    const seqStartBuffer = new Buffer([Seq.IAC, Seq.SB]);
+    const seqStartBuffer = new Buffer([Seq.IAC, Seq.SB, Opts.OPT_GMCP]);
     const seqEndBuffer = new Buffer([Seq.IAC, Seq.SE]);
 
-    this.socket.write(Buffer.concat([seqStartBuffer, dataBuffer, seqEndBuffer], gmcpData.length + 4));
+    this.socket.write(Buffer.concat([seqStartBuffer, dataBuffer, seqEndBuffer], gmcpData.length + 5));
   }
 
   attach(connection) {


### PR DESCRIPTION
The fix is self-explanatory.  But to test, login to the mud using a GMCP-supported client like Mudlet.  Then immediately type `lua display(gmcp)`.  You should probably see something like:
`nil`
Shutdown the mud, and then go to player-events/player-events.js, and in the enterRoom event (or make one if it doesn't exist), do something like this:
this.socket.socket.sendGMCP('gmcp.Char.name', this.name);
Then, run the mud again and reconnect.  Then after logging in, you should see GMCP data coming in.  To view it, type: `lua display(gmcp)`.  If you want to reset your locally stored info, you can type: `lua gmcp = nil`. Then to see data get repopulated, move to the next room.