### PR TITLE
Feature: GMCP data from user client now available.

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,7 +224,11 @@ class TelnetSocket extends EventEmitter
 
     while (i < inputbuf.length) {
       if (inputbuf[i] !== Seq.IAC) {
-        cleanbuf[cleanlen++] = inputbuf[i++];
+        if (inputbuf[i] < 32) { // Skip any freaky control codes.
+          i++;
+        } else {
+          cleanbuf[cleanlen++] = inputbuf[i++];
+        }
         continue;
       }
 

--- a/index.js
+++ b/index.js
@@ -170,11 +170,13 @@ class TelnetSocket extends EventEmitter
       // them separately. Some client auto-connect features do this
       let bucket = [];
       for (let i = 0; i < inputlen; i++) {
-        if (databuf[i] !== 10) { // \n
+        if (databuf[i] !== 10 && databuf[i] !== 13) { // neither LF nor CR
           bucket.push(databuf[i]);
         } else {
-          this.input(Buffer.from(bucket));
-          bucket = [];
+          if (bucket.length) {
+            this.input(Buffer.from(bucket));
+            bucket = [];
+          }
         }
       }
 
@@ -325,7 +327,7 @@ class TelnetSocket extends EventEmitter
      * @event TelnetSocket#data
      * @param {Buffer} data
      */
-    this.emit('data', cleanbuf.slice(0, cleanlen - 1));
+    this.emit('data', cleanbuf.slice(0, cleanlen >= cleanbuf.length ? undefined : cleanlen));  // special processing required for slice() to work.
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -173,10 +173,13 @@ class TelnetSocket extends EventEmitter
         if (databuf[i] !== 10 && databuf[i] !== 13) { // neither LF nor CR
           bucket.push(databuf[i]);
         } else {
-          if (bucket.length) {
-            this.input(Buffer.from(bucket));
-            bucket = [];
+          // look ahead to see if our newline delimiter is part of a combo.
+          if (i+1 < inputlen && (databuf[i+1] === 10 || databuf[i+1 === 13])
+            && databuf[i] !== databuf[i+1]) {
+            i++;
           }
+          this.input(Buffer.from(bucket));
+          bucket = [];
         }
       }
 

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ class TelnetSocket extends EventEmitter
     this.maxInputLength = opts.maxInputLength || 512;
     this.echoing = true;
     this.gaMode = null;
+    this.gmcpData = null;
   }
 
   get readable() {
@@ -149,6 +150,11 @@ class TelnetSocket extends EventEmitter
     connection.on('error', err => this.emit('error', err));
 
     this.socket.write("\r\n");
+    // Obtain GMCP client info.
+    this.telnetCommand(Seq.WILL, Opts.OPT_GMCP);
+    this.once('gmcp', (gmcpPackage, gmcpData) => {
+      this.gmcpData = gmcpData;
+    });
     connection.on('data', (databuf) => {
       databuf.copy(inputbuf, inputlen);
       inputlen += databuf.length;


### PR DESCRIPTION
GMCP data like Client name and version are now available with this commit.
If the user connects to the mud with GMCP turned ON, you can access the data via:
player.socket.socket.gmcpData
With Mudlet, the `client` and `version` properties will be returned.