### PR TITLE
Feature: GMCP data from user client now available.

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,10 +131,10 @@ class TelnetSocket extends EventEmitter
   sendGMCP(gmcpPackage, data) {
     const gmcpData = gmcpPackage + ' ' + JSON.stringify(data);
     const dataBuffer = Buffer.from(gmcpData);
-    const seqStartBuffer = new Buffer([Seq.IAC, Seq.SB]);
+    const seqStartBuffer = new Buffer([Seq.IAC, Seq.SB, Opts.OPT_GMCP]);
     const seqEndBuffer = new Buffer([Seq.IAC, Seq.SE]);
 
-    this.socket.write(Buffer.concat([seqStartBuffer, dataBuffer, seqEndBuffer], gmcpData.length + 4));
+    this.socket.write(Buffer.concat([seqStartBuffer, dataBuffer, seqEndBuffer], gmcpData.length + 5));
   }
 
   attach(connection) {

--- a/index.js
+++ b/index.js
@@ -34,6 +34,7 @@ class TelnetSocket extends EventEmitter
     this.maxInputLength = opts.maxInputLength || 512;
     this.echoing = true;
     this.gaMode = null;
+    this.gmcpData = null;
   }
 
   get readable() {
@@ -149,6 +150,11 @@ class TelnetSocket extends EventEmitter
     connection.on('error', err => this.emit('error', err));
 
     this.socket.write("\r\n");
+    this.telnetCommand(Seq.WILL, Opts.OPT_GMCP);
+    this.once('GMCP', (gmcpPackage, gmcpData) => {
+      this.gmcpData = gmcpData;
+    });
+    
     connection.on('data', (databuf) => {
       databuf.copy(inputbuf, inputlen);
       inputlen += databuf.length;


### PR DESCRIPTION
GMCP data like Client name and version are now available with this commit.  
If the user connects to the mud with GMCP turned ON, you can access the data via:  
player.socket.socket.gmcpData  
With Mudlet, the `client` and `version` properties will be returned.